### PR TITLE
Improve XML documentation comments for number and time functions

### DIFF
--- a/src/RndF/Functions/NumberF/Rnd.NumberF.GetUInt32.cs
+++ b/src/RndF/Functions/NumberF/Rnd.NumberF.GetUInt32.cs
@@ -21,12 +21,12 @@ public static partial class Rnd
 			GetUInt32(0, uint.MaxValue);
 
 		/// <summary>
-		/// Returns a random positive integer between <see langword="0"/> and <see cref="uint.MaxValue"/> inclusive.
+		/// Returns a random positive integer between <see langword="0"/> and <paramref name="max"/> inclusive.
 		/// </summary>
 		/// <remarks>
 		/// Don't share code with other GetUIntxx() methods for memory allocation reasons.
 		/// </remarks>
-		/// <param name="max">Maximum acceptable value</param>
+		/// <param name="max">Maximum acceptable value.</param>
 		/// <returns>Random number.</returns>
 		/// <exception cref="MaximumLessThanMinimumException"/>
 		public static uint GetUInt32(uint max) =>

--- a/src/RndF/Functions/TimeF/Rnd.TimeF.Get.cs
+++ b/src/RndF/Functions/TimeF/Rnd.TimeF.Get.cs
@@ -11,8 +11,9 @@ public static partial class Rnd
 	public static partial class TimeF
 	{
 		/// <summary>
-		/// Return a random Time
+		/// Return a random Time.
 		/// </summary>
+		/// <returns>Random time.</returns>
 		public static TimeOnly Get() =>
 			new(
 				hour: RandomNumberGenerator.GetInt32(0, DateTimeF.HourMaxExclusive),


### PR DESCRIPTION
## Summary
This PR improves the XML documentation comments in the RndF library by fixing inaccuracies and adding missing documentation elements.

## Key Changes
- **NumberF.GetUInt32**: Updated the summary to correctly reference `max` parameter instead of hardcoded `uint.MaxValue`, and added a period to the parameter description for consistency
- **TimeF.Get**: Added missing `<returns>` XML documentation tag and corrected the summary to end with a period

## Details
These changes ensure that:
1. The documentation accurately reflects the actual behavior of the methods
2. All public methods have complete XML documentation with proper formatting
3. Documentation is consistent across the codebase with proper punctuation

https://claude.ai/code/session_01MeEMywUn82yZ4eP7g14U4j